### PR TITLE
bug fix: wrong argument

### DIFF
--- a/app.R
+++ b/app.R
@@ -149,7 +149,7 @@ server <- function(input, output) {
       
       # Run statcheck
       suppressMessages(
-        res <- statcheck::statcheck(text, OneTailedTests = input$one_tail)
+        res <- statcheck::statcheck(text, OneTailedTxt = input$one_tail)
       )
       
       # Check whether any results were found


### PR DESCRIPTION
called wrong argument to correct for one tailed tests: shouldn't be OneTailedTests (this treats all tests as one-tailed), but OneTailedTxt (searches text for one-tailed & corrects if it wouldn't be an error)