### PR TITLE
bug fix: paste different pages of pdf files together

### DIFF
--- a/app.R
+++ b/app.R
@@ -170,7 +170,7 @@ server <- function(input, output) {
           
           # Extract text from the file, depending on the file extension
           if (file_extension == "pdf") {
-            text <- pdftools::pdf_text(file$datapath)
+            text <- paste(pdftools::pdf_text(file$datapath), collapse = "\n")
           } else if (file_extension %in% c("htm", "html"))  {
             html <- paste(readLines(file$datapath), collapse = "\n")
             text <- htm2txt::htm2txt(html)


### PR DESCRIPTION
for some reason, multiple-page pdfs were not properly read in anymore. The problem seemed to be that pdftools stores text from separate pages in different elements in a vector. Solved it by "pasting" together these separate elements into one element.