### PR TITLE
Use more advanced file - to - text methods from statcheck package

### DIFF
--- a/app.R
+++ b/app.R
@@ -189,8 +189,20 @@ server <- function(input, output) {
             
             # HTML ----------
           } else if (file_extension %in% c("htm", "html"))  {
-            html <- paste(readLines(file$datapath), collapse = "\n")
-            text <- htm2txt::htm2txt(html)
+            
+            try_checkhtml <- try(suppressMessages(
+              checkHTML(file$datapath, OneTailedTxt = input$one_tail)
+            ))
+            
+            if("try-error" %in% class(try_checkhtml)){
+              statcheck_results[[i]] <- NULL
+            } else {
+              statcheck_results[[i]] <- try_checkhtml
+              
+              # add filename to source column
+              statcheck_results[[i]]$source <- file$name
+            }
+            
             
             # DOCX -----------
           } else if (file_extension %in% c("doc", "docx")) {

--- a/app.R
+++ b/app.R
@@ -182,8 +182,10 @@ server <- function(input, output) {
             } else {
               statcheck_results[[i]] <- try_checkpdf
               
-              # add filename to source column
-              statcheck_results[[i]]$source <- file$name
+              if(!is.null(try_checkpdf)){
+                # add filename to source column
+                statcheck_results[[i]]$source <- file$name
+              }
             }
             
             
@@ -199,8 +201,10 @@ server <- function(input, output) {
             } else {
               statcheck_results[[i]] <- try_checkhtml
               
-              # add filename to source column
-              statcheck_results[[i]]$source <- file$name
+              if(!is.null(try_checkhtml)){
+                # add filename to source column
+                statcheck_results[[i]]$source <- file$name
+              }
             }
             
             
@@ -233,7 +237,7 @@ server <- function(input, output) {
         }
         
         res <- do.call(rbind, statcheck_results)
-  
+        
         # Print which statcheck version was run
         version <- sessionInfo()$otherPkgs$statcheck$Version
         output$sessionInfo <- renderText({

--- a/app.R
+++ b/app.R
@@ -168,31 +168,56 @@ server <- function(input, output) {
           # Check whether the user supplied a PDF, HTML, or MS Word file
           file_extension <- tools::file_ext(file$name)
           
-          # Extract text from the file, depending on the file extension
+          # Different file types require different strategies to run statcheck
+          
+          # PDF -----------
           if (file_extension == "pdf") {
-            text <- paste(pdftools::pdf_text(file$datapath), collapse = "\n")
+            
+            try_checkpdf <- try(suppressMessages(
+              checkPDF(file$datapath, OneTailedTxt = input$one_tail)
+            ))
+            
+            if("try-error" %in% class(try_checkpdf)){
+              statcheck_results[[i]] <- NULL
+            } else {
+              statcheck_results[[i]] <- try_checkpdf
+              
+              # add filename to source column
+              statcheck_results[[i]]$source <- file$name
+            }
+            
+            
+            # HTML ----------
           } else if (file_extension %in% c("htm", "html"))  {
             html <- paste(readLines(file$datapath), collapse = "\n")
             text <- htm2txt::htm2txt(html)
+            
+            # DOCX -----------
           } else if (file_extension %in% c("doc", "docx")) {
+            
+            # for a word document, there is no default statcheck function yet
+            # we first need to extract the plain text and then run the basic
+            # statcheck function
+            
             word <- readtext::readtext(file$datapath)
             text <- word$text
-          }
-          
-          # store filename to return in final dataframe
-          names(text) <- file$name
-          
-          # run statcheck in a try() environment to avoid the app from breaking
-          # if a paper throws an error
-          try_statcheck <- try(suppressMessages(
+            
+            # store filename to return in final dataframe
+            names(text) <- file$name
+            
+            # run statcheck in a try() environment to avoid the app from breaking
+            # if a paper throws an error
+            try_statcheck <- try(suppressMessages(
               statcheck::statcheck(text, OneTailedTxt = input$one_tail)
-          ))
-          
-          if("try-error" %in% class(try_statcheck)){
-            statcheck_results[[i]] <- NULL
-          } else {
-            statcheck_results[[i]] <- try_statcheck
+            ))
+            
+            if("try-error" %in% class(try_statcheck)){
+              statcheck_results[[i]] <- NULL
+            } else {
+              statcheck_results[[i]] <- try_statcheck
+            }
           }
+          
         }
         
         res <- do.call(rbind, statcheck_results)


### PR DESCRIPTION
before, a more basic text conversion strategy was used, but in this update, the actual text conversion that is also used in the statcheck R package is used (incl. solutions for weird encodings).