### PR TITLE
switch latex engine to support unicode

### DIFF
--- a/templates/report_template.Rmd
+++ b/templates/report_template.Rmd
@@ -1,6 +1,8 @@
 ---
 title: "statcheck on the web // report"
-output: pdf_document
+output: 
+  pdf_document:
+    latex_engine: xelatex
 params:
   results: NULL
   file_name: NULL
@@ -57,7 +59,7 @@ if (nrow(results) > 0) {
 # Summary
 `r if (nrow(results) > 0) paste( "In total, statcheck detected", total_results, "statistical results reported in APA style.", "Of these,", total_consistent, if (total_consistent == 1) "is" else "are", "consistent,", total_inconsistent, if (total_inconsistent == 1) "is" else "are", "inconsistent,", "and", total_dec_inconsistent, if (total_dec_inconsistent == 1) "is" else "are", "a decision inconsistency." )`
 
-`r if (nrow(results) == 0) paste0("**Statcheck did not detect any APA-reported Null Hypothesis Significance Tests.** \\newline \\newline ", "If you think your document does contain tests that statcheck should have picked up, please check if the results are reported completely ", "(i.e., a test statistic, degrees of freedom when applicable, and a p-value) and in APA reporting style. Another common reason why statcheck may not detect results is when there are issues in PDF conversion, in which case you could try uploading the file in HTML or DOCX, if available. \\newline \\newline ", "For more information on what statcheck can and cannot detect, please see the FAQ page at http://statcheck.io.")` 
+`r if (nrow(results) == 0) paste0("**Statcheck did not detect any APA-reported Null Hypothesis Significance Tests.** \\newline \\newline ", "\\emph{Statcheck should be able to detect and check the following tests:} \\newline ", "• **T**-tests (e.g., *t*(28) = 2.20, *p* = .036) \\newline ", "• **F**-tests (e.g., *F*(2, 28) = 2.20, *p* = .130) \\newline ", "• **Z**-tests (e.g., *z* = 2.04, *p* < .05) \\newline ", "• \\(\\chi^2\\)-tests (e.g., \\(\\chi^2(1, N = 81) = 3.25, p = 0.07\\)) \\newline ", "• **Correlations** (e.g., *r*(523) = .14, *p* = .001) \\newline ", "• **Q**-tests (e.g., *Q-within*(2) = 2.20, *p* = .03) \\newline \\newline ", "\\emph{Common reasons why statcheck does not pick up results:} \\newline", "• \\textbf{Results are not reported completely.} Solution: report tests completely with a test statistic, degrees of freedom (when applicable), and a *p*-value. \\newline ", "• \\textbf{Results are not reported according to APA style.} Solution: match the reporting styles above. Minor spacing deviations are allowed, values can be exact (=) or inexact (< or >), \\(\\chi^2\\) sample size is optional, and Q-tests (Q, Qwithin, Qbetween) are recognized. \\newline ", "• \\textbf{Results are not reported in the full text.} Statcheck generally cannot detect statistics in tables, where the necessary information isn’t grouped together. \\newline ", "• \\textbf{There are issues in converting the PDF/HTML/DOCX to plain text.} Statcheck converts documents to plain text, and some symbols may be mistranslated. Using another file format may help. \\newline \\newline ", "For more information on what statcheck can and cannot detect, please see the FAQ page at https://statcheck.io. You can find a general explanation of statcheck below.")` 
 
 ------------------------------------------------------------------------
 
@@ -81,5 +83,5 @@ Statcheck is a "spellchecker" for statistics. It searches text for Null Hypothes
 
 ***We strongly advise against making decisions about a manuscript based solely on a statcheck report.***
 
-For more information about what statcheck can and cannot do, please take a look at the FAQ page at <http://statcheck.io>.
+For more information about what statcheck can and cannot do, please take a look at the FAQ page at <https://statcheck.io>.
 


### PR DESCRIPTION
sometimes a report failed to generate if there was a unicode character in the manuscript (e.g., a non-standard minus sign). by using xelatex, this is fixed, while nothing else really changes.